### PR TITLE
Canonical URLを設定する

### DIFF
--- a/src/_shared/head.jade
+++ b/src/_shared/head.jade
@@ -5,6 +5,7 @@ script(src="/js/umbrella.min.js")
 script(src="/js/stickyfill.min.js")
 script(src="/js/haiiro_icon.js")
 
+link(rel="canonical" href= public._data.meta.url)
 link(rel="apple-touch-icon" sizes="57x57" href="/images/icons/apple-touch-icon-57x57.png")
 link(rel="apple-touch-icon" sizes="60x60" href="/images/icons/apple-touch-icon-60x60.png")
 link(rel="apple-touch-icon" sizes="72x72" href="/images/icons/apple-touch-icon-72x72.png")


### PR DESCRIPTION
正規化されたURLとしてトップページのURLを提示するようにしました。
例えば、Worksを開いていたり、`#planning` とかアンカーが付いていた時に、はてなブックマークなどで誘導されます。
挙動としてこうなって問題ないようでしたらマージしてください @haiji505 

![image](https://cloud.githubusercontent.com/assets/85887/15810006/9ff2a390-2b4e-11e6-8ede-cf882918b6e0.png)
